### PR TITLE
Update the Codenvy SDK launcher to be more resilient

### DIFF
--- a/codenvy_sdk.sh
+++ b/codenvy_sdk.sh
@@ -1,29 +1,50 @@
 #!/bin/sh
-
-cd assembly-sdk/target/tomcat-ide
+#
+# Startup script for Codenvy SDK.  Downloads Tomcat for running projects within the IDE if necessary.
 
 TOMCAT="tomcat"
-if [ ! -d "$TOMCAT" ]
+TOMCAT_IDE_DIR="assembly-sdk/target/tomcat-ide"
 
+if [ ! -d "${TOMCAT_IDE_DIR}" ]
 then
+  echo "$(tput setaf 1)ERROR: Looks like you have not installed the Codenvy SDK."$(tput sgr0)
+  echo "$(tput setaf 1)ERROR: Please run 'mvn clean install' and try again."$(tput sgr0)
+  echo "$(tput setaf 1)ERROR: For more information, please see the Codenvy SDK README:"$(tput sgr0)
+  echo "$(tput setaf 1)ERROR:     https://github.com/codenvy/sdk"$(tput sgr0)
+  exit 1
+fi
 
-echo "$(tput setaf 2)INFO: No Tomcat found for runners"$(tput sgr0)
+cd "${TOMCAT_IDE_DIR}"
 
-echo "$(tput setaf 2)INFO: Downloading Apache Tomcat for runners"$(tput sgr0)
-sleep 2
-tomcatVersion="7.0.53"
-tomcatDir="apache-tomcat-"${tomcatVersion}
-curl http://apache-mirror.telesys.org.ua/tomcat/tomcat-7/v${tomcatVersion}/bin/apache-tomcat-${tomcatVersion}.zip > $tomcatDir.zip
-unzip $tomcatDir
-rm apache-tomcat-${tomcatVersion}.zip
-mv $tomcatDir tomcat
-rm -rf $tomcatDir
-echo "$(tput setaf 2)INFO: Tomcat $tomcatVersion for runners successfully downloaded"$(tput sgr0)
+if [ ! -d "$TOMCAT" ]
+then
+  echo "$(tput setaf 2)INFO: No Tomcat found for runners"$(tput sgr0)
+  echo "$(tput setaf 2)INFO: Downloading Apache Tomcat for runners"$(tput sgr0)
+
+  sleep 2
+
+  tomcatVersion="7.0.53"
+  tomcatDir="apache-tomcat-"${tomcatVersion}
+  tomcatBinUrl="http://archive.apache.org/dist/tomcat/tomcat-7/v${tomcatVersion}/bin/apache-tomcat-${tomcatVersion}.zip"
+
+  curl -# -f -o ${tomcatDir}.zip ${tomcatBinUrl}
+
+  if [ $? -ne 0 ]
+  then
+    echo "$(tput setaf 1)ERROR: Unable to download Tomcat ${tomcatVersion} from ${tomcatBinUrl}"$(tput sgr0)
+    exit 1
+  fi
+
+  unzip -q ${tomcatDir}
+  rm apache-tomcat-${tomcatVersion}.zip
+  mv ${tomcatDir} ${TOMCAT}
+  rm -rf ${tomcatDir}
+
+  echo "$(tput setaf 2)INFO: Tomcat ${tomcatVersion} for runners successfully downloaded"$(tput sgr0)
 fi
 
 echo "$(tput setaf 2)INFO: Launching Codenvy SDK"$(tput sgr0)
 sleep 1
 
-  cd bin
-  ./codenvy.sh $*
-
+cd bin
+./codenvy.sh $*


### PR DESCRIPTION
- Handle situation where user has not ran 'mvn clean install' or ran 'mvn clean'
- Handle situation where Tomcat download fails
- Updated Tomcat download url to use Apache Archive URL vs. Apache Mirror URL to
  avoid the script failing when Tomcat's version updates (Apache Mirror hosts
  only host the latest version while the Apache Archive host hosts all versions)
- Various code/interface cleanups
