### PR TITLE
Fix random it test failure: Wait until the server is really started (fro...

### DIFF
--- a/sdk-qa/pom.xml
+++ b/sdk-qa/pom.xml
@@ -33,9 +33,16 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.googlecode.grep4j</groupId>
+            <artifactId>grep4j</artifactId>
+            <version>1.8.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.concordion</groupId>
@@ -116,6 +123,10 @@
                                 <property>
                                     <name>concordion.output.dir</name>
                                     <value>${project.build.directory}/concordion</value>
+                                </property>
+                                <property>
+                                    <name>codenvy.ide.path</name>
+                                    <value>${codenvy.ide.path}</value>
                                 </property>
                             </systemProperties>
                         </configuration>

--- a/sdk-qa/src/test/java/com/codenvy/sdk/qa/AbstractIntegrationTest.java
+++ b/sdk-qa/src/test/java/com/codenvy/sdk/qa/AbstractIntegrationTest.java
@@ -17,8 +17,17 @@
  */
 package com.codenvy.sdk.qa;
 
+import static org.grep4j.core.Grep4j.constantExpression;
+import static org.grep4j.core.Grep4j.grep;
+import static org.grep4j.core.fluent.Dictionary.on;
+
+import java.util.logging.Logger;
+
 import org.concordion.api.extension.Extension;
 import org.concordion.integration.junit4.ConcordionRunner;
+import org.grep4j.core.model.Profile;
+import org.grep4j.core.model.ProfileBuilder;
+import org.grep4j.core.result.GrepResults;
 import org.jboss.arquillian.phantom.resolver.ResolvingPhantomJSDriverService;
 import org.junit.After;
 import org.junit.Before;
@@ -27,6 +36,8 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.codenvy.sdk.qa.concordion.CodenvyConcordionExtension;
 
@@ -35,6 +46,9 @@ import com.codenvy.sdk.qa.concordion.CodenvyConcordionExtension;
  */
 @RunWith(ConcordionRunner.class)
 public class AbstractIntegrationTest {
+
+    private final static Logger       log       = Logger.getLogger(AbstractIntegrationTest.class.getName());
+
     protected WebDriver               driver;
 
     @Extension
@@ -55,5 +69,25 @@ public class AbstractIntegrationTest {
             driver.quit();
             driver = null;
         }
+    }
+
+    public String serverIsStarted(String logFileLocation) {
+        // get server location
+        String serverLocation = System.getProperty("codenvy.ide.path");
+        final Profile profile = ProfileBuilder.newBuilder()
+                                              .name("Local server log")
+                                              .filePath(serverLocation + logFileLocation)
+                                              .onLocalhost()
+                                              .build();
+        if (new WebDriverWait(driver, 10).until(new ExpectedCondition<Boolean>() {
+            @Override
+            public Boolean apply(WebDriver arg0) {
+                GrepResults results = grep(constantExpression("Server startup in"), on(profile));                
+                return !results.toString().isEmpty();
+            }
+        })) {
+            return "is started";
+        }
+        return "is not started";
     }
 }

--- a/sdk-qa/src/test/resources/com/codenvy/sdk/qa/itests/ServerStarted.html
+++ b/sdk-qa/src/test/resources/com/codenvy/sdk/qa/itests/ServerStarted.html
@@ -9,6 +9,8 @@
 
 ## Given
 - Server url:  <span c:set="#url">http://localhost:8280</span>
+- The server logs in <span c:set="#logpath">/logs/catalina.out</span> say server <span c:assertEquals="serverIsStarted(#logpath)">is started</span>.
+
 
 ## When
 - The user <span c:assertEquals="access(#url)">access</span> the server url.


### PR DESCRIPTION
...m logs/catalina.out) before starting the test.

If the server takes too much time to start, the ITest is failing. This patch wait until the line containing `Server startup in` appears in the log file before starting the test.
