### PR TITLE
Put the datasource server component  in its separate datasource war

### DIFF
--- a/assembly-sdk/pom.xml
+++ b/assembly-sdk/pom.xml
@@ -53,8 +53,8 @@
         </dependency>
         <dependency>
             <groupId>com.codenvy.ide</groupId>
-            <artifactId>codenvy-ext-datasource-server-war</artifactId>
-            <version>${com.codenvy.ide.version}</version>
+            <artifactId>codenvy-ext-datasource-server-war-sdk</artifactId>
+            <version>${datasource-plugin.version}</version>
             <type>war</type>
         </dependency>
         <dependency>
@@ -521,7 +521,7 @@
                                     <fileset dir="${project.build.directory}/packager-conf/war/ide" />
                                 </war>
                                 <copy file="${project.build.directory}/packager-conf/war/assembly-platform-api-${project.version}.war" overwrite="true" tofile="${project.build.directory}/tomcat-ide/webapps/api.war" />
-                                <copy file="${project.build.directory}/packager-conf/war/codenvy-ext-datasource-server-war-${com.codenvy.ide.version}.war" overwrite="true" tofile="${project.build.directory}/tomcat-ide/webapps/datasource.war" />
+                                <copy file="${project.build.directory}/packager-conf/war/codenvy-ext-datasource-server-war-sdk-${com.codenvy.ide.version}.war" overwrite="true" tofile="${project.build.directory}/tomcat-ide/webapps/datasource.war" />
                                 <chmod dir="${project.build.directory}/tomcat-ide" includes="*.sh" perm="+x" />
                             </target>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <commons.compress.version>1.6</commons.compress.version>
         <concordion.ext.version>1.1.1</concordion.ext.version>
         <concordion.version>1.4.4</concordion.version>
+        <datasource-plugin.version>3.0.0-M15-SNAPSHOT</datasource-plugin.version>
         <enforcer.plugin.version>1.0.1</enforcer.plugin.version>
         <everrest.version>1.1.10</everrest.version>
         <failsafe.plugin.version>2.6</failsafe.plugin.version>


### PR DESCRIPTION
The datasource service-side is moved from being a part of the platform-api war to its own war inside the SDK.
