### PR TITLE
Integration test: wait  up to 1 minute for the string "Server startup ...

### DIFF
--- a/sdk-qa/src/test/java/com/codenvy/sdk/qa/AbstractIntegrationTest.java
+++ b/sdk-qa/src/test/java/com/codenvy/sdk/qa/AbstractIntegrationTest.java
@@ -79,7 +79,7 @@ public class AbstractIntegrationTest {
                                               .filePath(serverLocation + logFileLocation)
                                               .onLocalhost()
                                               .build();
-        if (new WebDriverWait(driver, 10).until(new ExpectedCondition<Boolean>() {
+        if (new WebDriverWait(driver, 60).until(new ExpectedCondition<Boolean>() {
             @Override
             public Boolean apply(WebDriver arg0) {
                 GrepResults results = grep(constantExpression("Server startup in"), on(profile));                


### PR DESCRIPTION
Integration test: wait up to 1 minute for the string "Server startup in" in the log file before starting the integration test
Seems 10 secs is not enough
