### PR TITLE
Idex-984 Depend on editor-common, orion plugin and codemirror plugin

### DIFF
--- a/assembly-ide/pom.xml
+++ b/assembly-ide/pom.xml
@@ -99,6 +99,11 @@
             <version>${codenvy.ide.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.codenvy.ide</groupId>
+            <artifactId>codenvy-ide-jseditor</artifactId>
+            <version>${codenvy.ide.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.codenvy.platform-api</groupId>
             <artifactId>codenvy-api-user</artifactId>
             <version>${codenvy.platform-api.version}</version>
@@ -147,6 +152,16 @@
             <groupId>com.codenvy.plugin-bower</groupId>
             <artifactId>bower-client</artifactId>
             <version>${codenvy.plugin.bower.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.codenvy.plugin-editor-codemirror</groupId>
+            <artifactId>plugin-editor-codemirror</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.codenvy.plugin-editor-orion</groupId>
+            <artifactId>plugin-editor-orion</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.codenvy.plugin-npm</groupId>

--- a/assembly-ide/src/main/resources/com/codenvy/ide/IDE.gwt.xml
+++ b/assembly-ide/src/main/resources/com/codenvy/ide/IDE.gwt.xml
@@ -41,6 +41,8 @@
     <inherits name='com.codenvy.ide.ext.ssh.Ssh'/>
     <inherits name='com.codenvy.ide.ext.tutorials.Tutorials'/>
     <inherits name='com.codenvy.ide.ext.datasource.Datasource'/>
+    <inherits name='com.codenvy.ide.editor.codemirror.CodeMirrorEditor'/>
+    <inherits name='com.codenvy.ide.editor.orion.OrionEditor'/>
 
     <inherits name='com.codenvy.api.Core'/>
     <inherits name='com.codenvy.api.Builder'/>

--- a/assembly-ide/src/main/resources/com/codenvy/ide/IDE_dev.gwt.xml
+++ b/assembly-ide/src/main/resources/com/codenvy/ide/IDE_dev.gwt.xml
@@ -35,11 +35,14 @@
     <inherits name='com.codenvy.ide.ext.java.jdi.JavaRuntimeExtension'/>
     <inherits name='com.codenvy.ide.extension.builder.Builder'/>
     <inherits name='com.codenvy.ide.extension.runner.Runner'/>
+    <inherits name='com.codenvy.ide.extension.maven.Maven'/>
     <inherits name='com.codenvy.ide.ext.git.Git'/>
     <inherits name='com.codenvy.ide.ext.github.GitHub'/>
     <inherits name='com.codenvy.ide.ext.ssh.Ssh'/>
     <inherits name='com.codenvy.ide.ext.tutorials.Tutorials'/>
     <inherits name='com.codenvy.ide.ext.datasource.Datasource'/>
+    <inherits name='com.codenvy.ide.editor.codemirror.CodeMirrorEditor'/>
+    <inherits name='com.codenvy.ide.editor.orion.OrionEditor'/>
 
     <inherits name='com.codenvy.api.Core'/>
     <inherits name='com.codenvy.api.Builder'/>
@@ -50,7 +53,8 @@
     <inherits name='com.codenvy.api.Analytics'/>
 
     <inherits name="com.codenvy.ide.ui.CodenvyUI"/>
-	<inherits name="com.codenvy.api.Workspace"/>
+    <inherits name="com.codenvy.api.Project"/>
+    <inherits name="com.codenvy.api.Workspace"/>
 
     <!-- Javascript & AngularJS plugins -->
     <inherits name="com.codenvy.plugin.angularjs.completion.dto.Completion" />


### PR DESCRIPTION
This pull request depends on IDEX-982 being merged and plugin-editor-codemirror and plugin-editor-orion jenkins job to run successfully.

It inserts the jseditor, plugin-editor-codemirror and plugin-editor-orion in the SDK.

The only visible change is a new dialog in preferences. It has no effect as the default editor is still harcoded (classic).
