### PR TITLE
Increasing Che portability

### DIFF
--- a/assembly-platform-api/.gitignore
+++ b/assembly-platform-api/.gitignore
@@ -1,0 +1,2 @@
+target/
+build/

--- a/assembly-platform-api/pom.xml
+++ b/assembly-platform-api/pom.xml
@@ -254,11 +254,6 @@
             <version>${org.everrest.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${org.slf4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>${javax.servlet.version}</version>
@@ -274,6 +269,12 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-coyote</artifactId>
             <version>${org.apache.tomcat.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${org.slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/assembly-platform-api/src/main/webapp/META-INF/context.xml
+++ b/assembly-platform-api/src/main/webapp/META-INF/context.xml
@@ -11,4 +11,7 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<Context allowCasualMultipartParsing="true" />
+
+<Context allowCasualMultipartParsing="true">
+<JarScanner scanBootstrapClassPath="true" scanAllDirectories="true" scanClassPath="true"/>
+</Context>


### PR DESCRIPTION
1) Set slf4j-log4j12 as provided, because it is supplied by tomcat. This jar is copied to tomcat libs directory by maven as described pom.xml of assembly-sdk
2) Added configuration for JarScanner component of tomcat to context.xml, for newer versions of tomcat (>=7.0.56) to be able to find DynaModules
3) Did sanity test, this does not seem to break any existing functionality

Thanks.