### PR TITLE
Adding configuration for JarScanner (Tomcat component) to find Che DynaM...

### DIFF
--- a/assembly-platform-api/src/main/webapp/META-INF/context.xml
+++ b/assembly-platform-api/src/main/webapp/META-INF/context.xml
@@ -11,4 +11,9 @@
       Codenvy, S.A. - initial API and implementation
 
 -->
-<Context allowCasualMultipartParsing="true" />
+
+<Context allowCasualMultipartParsing="true">
+<JarScanner scanBootstrapClassPath="true" scanAllDirectories="true" scanClassPath="true"/>
+</Context>
+
+


### PR DESCRIPTION
...odules. This is necessary from Tomcat 7.0.56, because default configuration of JarScanner is changed.